### PR TITLE
Use nullability attributes for out parameters

### DIFF
--- a/src/Danom/Option/Option.cs
+++ b/src/Danom/Option/Option.cs
@@ -2,6 +2,7 @@ namespace Danom
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -138,7 +139,7 @@ namespace Danom
         /// </summary>
         /// <param name="result"></param>
         /// <returns></returns>
-        public bool TryGet(out T result)
+        public bool TryGet([MaybeNullWhen(false)] out T result)
         {
             var success = true;
             result = DefaultWith(() =>

--- a/src/Danom/Result/Result.cs
+++ b/src/Danom/Result/Result.cs
@@ -1,6 +1,7 @@
 namespace Danom
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -128,7 +129,7 @@ namespace Danom
         /// </summary>
         /// <param name="value">The value if in Ok state, default otherwise.</param>
         /// <returns>True if the Result is in Ok state, false otherwise.</returns>
-        public bool TryGet(out T value)
+        public bool TryGet([MaybeNullWhen(false)] out T value)
         {
             value = IsOk ? _ok : default!;
             return IsOk;
@@ -139,7 +140,7 @@ namespace Danom
         /// </summary>
         /// <param name="error">The error if in Error state, default otherwise.</param>
         /// <returns>True if the Result is in Error state, false otherwise.</returns>
-        public bool TryGetError(out TError error)
+        public bool TryGetError([MaybeNullWhen(false)] out TError error)
         {
             error = IsError ? _error : default!;
             return IsError;


### PR DESCRIPTION
This helps nullability analysis when the return value of `TryGet` or `TryGetError` is used.

Example for Result:

```csharp
var result = Result<object, ResultErrors>.Error("Some error");
if (result.TryGet(out var value))
{
    // This is completely fine, we just checked the returned bool
    _ = value.ToString();
}

// Compiler warns here: "Dereference of a possibly null reference"
_ = value.ToString();
```