### PR TITLE
Typed HTTP results

### DIFF
--- a/Danom.sln
+++ b/Danom.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DanomBenchmark", "benchmark
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Danom.MinimalApi", "src\Danom.MinimalApi\Danom.MinimalApi.csproj", "{94B63411-6576-44D7-B0B3-CFC4D1B6321E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Danom.MinimalApi.Tests", "test\Danom.MinimalApi.Tests\Danom.MinimalApi.Tests.csproj", "{2C83DF78-A003-4FE3-A4B6-16C83D06563A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -143,6 +145,18 @@ Global
 		{94B63411-6576-44D7-B0B3-CFC4D1B6321E}.Release|x64.Build.0 = Release|Any CPU
 		{94B63411-6576-44D7-B0B3-CFC4D1B6321E}.Release|x86.ActiveCfg = Release|Any CPU
 		{94B63411-6576-44D7-B0B3-CFC4D1B6321E}.Release|x86.Build.0 = Release|Any CPU
+		{2C83DF78-A003-4FE3-A4B6-16C83D06563A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C83DF78-A003-4FE3-A4B6-16C83D06563A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C83DF78-A003-4FE3-A4B6-16C83D06563A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2C83DF78-A003-4FE3-A4B6-16C83D06563A}.Debug|x64.Build.0 = Debug|Any CPU
+		{2C83DF78-A003-4FE3-A4B6-16C83D06563A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2C83DF78-A003-4FE3-A4B6-16C83D06563A}.Debug|x86.Build.0 = Debug|Any CPU
+		{2C83DF78-A003-4FE3-A4B6-16C83D06563A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C83DF78-A003-4FE3-A4B6-16C83D06563A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C83DF78-A003-4FE3-A4B6-16C83D06563A}.Release|x64.ActiveCfg = Release|Any CPU
+		{2C83DF78-A003-4FE3-A4B6-16C83D06563A}.Release|x64.Build.0 = Release|Any CPU
+		{2C83DF78-A003-4FE3-A4B6-16C83D06563A}.Release|x86.ActiveCfg = Release|Any CPU
+		{2C83DF78-A003-4FE3-A4B6-16C83D06563A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -156,5 +170,6 @@ Global
 		{EF188F59-5C11-4BAA-A965-56C08C370C84} = {624FD20E-2393-4198-8DC9-AB02DCC12338}
 		{B78AD031-6E72-4006-A007-ABA49570F17E} = {624FD20E-2393-4198-8DC9-AB02DCC12338}
 		{94B63411-6576-44D7-B0B3-CFC4D1B6321E} = {606C9E49-7696-48B1-A799-B456E680C9F0}
+		{2C83DF78-A003-4FE3-A4B6-16C83D06563A} = {624FD20E-2393-4198-8DC9-AB02DCC12338}
 	EndGlobalSection
 EndGlobal

--- a/src/Danom.MinimalApi/TypedResults/TypedDanomResultExtensions.cs
+++ b/src/Danom.MinimalApi/TypedResults/TypedDanomResultExtensions.cs
@@ -1,0 +1,88 @@
+﻿namespace Danom.MinimalApi.TypedResults;
+
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+/// <summary>
+///     Extensions for handling Danom results in minimal APIs using <see cref="TypedResults"/>.
+///     Provides methods to convert Danom types to ASP.NET Core's <see cref="Results{TResult1,TResult2}"/>.
+/// </summary>
+public static class TypedDanomResultExtensions
+{
+    private const DynamicallyAccessedMemberTypes Methods = DynamicallyAccessedMemberTypes.PublicMethods |
+                                                           DynamicallyAccessedMemberTypes.NonPublicMethods;
+
+    /// <summary>
+    ///     Converts a <see cref="Option{T}"/> to a <see cref="Results{TResult1, TResult2}"/>.
+    ///     Returns a 200 OK result with the value if the <paramref name="option"/> is Some, or a <see cref="NotFound"/>
+    ///     if the <paramref name="option"/> is None.
+    /// </summary>
+    /// <param name="_"></param>
+    /// <param name="option">The option.</param>
+    /// <typeparam name="T">The value type of the <paramref name="option"/>.</typeparam>
+    /// <returns>The typed HTTP result.</returns>
+    public static Results<Ok<T>, NotFound> Option<T>(
+        this IResultExtensions _,
+        Option<T> option) =>
+        option.Match<Results<Ok<T>, NotFound>>(
+            some: value => TypedResults.Ok(value),
+            none: () => TypedResults.NotFound());
+
+    /// <summary>
+    ///     Converts a <see cref="Option{T}"/> to a <see cref="Results{TResult1, TResult2}"/>.
+    ///     Returns a 200 OK result with the value if the <paramref name="option"/> is Some, or invokes
+    ///     <paramref name="noneResult"/> to create the <see cref="IResult"/> if the <paramref name="option"/> is None.
+    /// </summary>
+    /// <param name="_"></param>
+    /// <param name="option">The option.</param>
+    /// <param name="noneResult">The factory function to create the <typeparamref name="TNotFoundResult"/>.</param>
+    /// <typeparam name="T">The value type of the <paramref name="option"/>.</typeparam>
+    /// <typeparam name="TNotFoundResult">The HTTP result type used when <paramref name="option"/> is empty.</typeparam>
+    /// <returns>The typed HTTP result.</returns>
+    public static Results<Ok<T>, TNotFoundResult> Option<T, [DynamicallyAccessedMembers(Methods)] TNotFoundResult>(
+        this IResultExtensions _,
+        Option<T> option,
+        Func<TNotFoundResult> noneResult) where TNotFoundResult : IResult =>
+        option.Match<Results<Ok<T>, TNotFoundResult>>(
+            some: value => TypedResults.Ok(value),
+            none: () => noneResult.Invoke());
+
+    /// <summary>
+    ///     Converts a <see cref="Result{T, TError}"/> to a <see cref="Results{TResult1, TResult2}"/>.
+    ///     Returns a 200 OK result with the value if the <paramref name="result"/> is ok or a 400 BadRequest result
+    ///     if the <paramref name="result"/> is an error.
+    /// </summary>
+    /// <param name="_"></param>
+    /// <param name="result">The result.</param>
+    /// <typeparam name="T">The value type of the <paramref name="result"/>.</typeparam>
+    /// <typeparam name="TError">The error type of the <paramref name="result"/>.</typeparam>
+    /// <returns>The typed HTTP result.</returns>
+    public static Results<Ok<T>, BadRequest<TError>> Result<T, TError>(
+        this IResultExtensions _, Result<T, TError> result) =>
+        result.Match<Results<Ok<T>, BadRequest<TError>>>(
+            ok: value => TypedResults.Ok(value),
+            error: error => TypedResults.BadRequest(error));
+
+    /// <summary>
+    ///     Converts a <see cref="Result{T, TError}"/> to a <see cref="Results{TResult1, TResult2}"/>.
+    ///     Returns a 200 OK result with the value if the <paramref name="result"/> is ok or invokes
+    ///     <paramref name="errorResult"/> to create the <see cref="IResult"/> if the <paramref name="result"/> is an
+    ///     error.
+    /// </summary>
+    /// <param name="_"></param>
+    /// <param name="result">The result.</param>
+    /// <param name="errorResult">
+    ///     Conversion from <typeparamref name="TError"/> to <typeparamref name="TErrorResult"/>.
+    /// </param>
+    /// <typeparam name="T">The value type of the <paramref name="result"/>.</typeparam>
+    /// <typeparam name="TError">The error type of the <paramref name="result"/>.</typeparam>
+    /// <typeparam name="TErrorResult">The HTTP result type used when <paramref name="result"/> is an error.</typeparam>
+    /// <returns>The typed HTTP result.</returns>
+    public static Results<Ok<T>, TErrorResult> Result<T, TError, [DynamicallyAccessedMembers(Methods)] TErrorResult>(
+        this IResultExtensions _, Result<T, TError> result, Func<TError, TErrorResult> errorResult)
+        where TErrorResult : IResult =>
+        result.Match<Results<Ok<T>, TErrorResult>>(
+            ok: value => TypedResults.Ok(value),
+            error: error => errorResult(error));
+}

--- a/test/Danom.MinimalApi.Tests/Danom.MinimalApi.Tests.csproj
+++ b/test/Danom.MinimalApi.Tests/Danom.MinimalApi.Tests.csproj
@@ -1,0 +1,33 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <NoWarn>IDE0028</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.*">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Danom.MinimalApi\Danom.MinimalApi.csproj" />
+    <ProjectReference Include="..\TestHelpers\TestHelpers.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Danom.MinimalApi.Tests/Extensions.cs
+++ b/test/Danom.MinimalApi.Tests/Extensions.cs
@@ -1,0 +1,35 @@
+﻿namespace Danom.MinimalApi.Tests;
+
+using System.Text.Json;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.DependencyInjection;
+
+internal static class Extensions
+{
+    public static async Task<HttpResponse> ToResponse(this IResult httpResult)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        var responseStream = new MemoryStream();
+        var httpContext = new DefaultHttpContext
+        {
+            ServiceScopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>(),
+            Features =
+            {
+                [typeof(IHttpResponseBodyFeature)] = new StreamResponseBodyFeature(responseStream),
+            },
+        };
+
+        await httpResult.ExecuteAsync(httpContext);
+
+        return httpContext.Response;
+    }
+
+    public static T? DeserializeBody<T>(this HttpResponse httpResponse)
+    {
+        var stream = httpResponse.Body;
+        stream.Position = 0;
+        return JsonSerializer.Deserialize<T>(stream, JsonSerializerOptions.Web);
+    }
+}

--- a/test/Danom.MinimalApi.Tests/TypedResults/TypedDanomResultExtensionsTests.cs
+++ b/test/Danom.MinimalApi.Tests/TypedResults/TypedDanomResultExtensionsTests.cs
@@ -1,0 +1,119 @@
+﻿namespace Danom.MinimalApi.Tests.TypedResults;
+
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Danom.MinimalApi.TypedResults;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+public static class TypedDanomResultExtensionsTests
+{
+    public static class OptionTests
+    {
+        [Fact]
+        public static async Task Some_NoConversion_200WithJson()
+        {
+            var value = new SomeType(123);
+            var option = Option.Some(new SomeType(123));
+
+            var httpResult = Results.Extensions.Option(option);
+
+            var response = await httpResult.ToResponse();
+            Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
+            Assert.Equal(value, response.DeserializeBody<SomeType>());
+        }
+
+        [Fact]
+        public static async Task Some_Conversion_200WithJson()
+        {
+            var value = new SomeType(123);
+            var option = Option.Some(new SomeType(123));
+
+            var httpResult = Results.Extensions.Option(option, () => throw new UnreachableException());
+
+            var response = await httpResult.ToResponse();
+            Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
+            Assert.Equal(value, response.DeserializeBody<SomeType>());
+        }
+
+        [Fact]
+        public static async Task None_NoConversion_404()
+        {
+            var option = Option.None();
+
+            var httpResult = Results.Extensions.Option(option);
+
+            var response = await httpResult.ToResponse();
+            Assert.Equal(StatusCodes.Status404NotFound, response.StatusCode);
+        }
+
+        [Fact]
+        public static async Task None_WithConversion_UsesConversion()
+        {
+            var option = Option.None();
+
+            var httpResult = Results.Extensions.Option(option, TypedResults.Conflict);
+
+            var response = await httpResult.ToResponse();
+            Assert.Equal(StatusCodes.Status409Conflict, response.StatusCode);
+        }
+    }
+
+    public static class ResultTests
+    {
+        [Fact]
+        public static async Task Ok_NoConversion_200WithJson()
+        {
+            var value = new SomeType(123);
+            var result = Result.Ok(new SomeType(123));
+
+            var httpResult = Results.Extensions.Result(result);
+
+            var response = await httpResult.ToResponse();
+            Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
+            Assert.Equal(value, response.DeserializeBody<SomeType>());
+        }
+
+        [Fact]
+        public static async Task Ok_Conversion_200WithJson()
+        {
+            var value = new SomeType(123);
+            var result = Result.Ok(new SomeType(123));
+
+            var httpResult = Results.Extensions.Result(result, IResult (_) => throw new UnreachableException());
+
+            var response = await httpResult.ToResponse();
+            Assert.Equal(StatusCodes.Status200OK, response.StatusCode);
+            Assert.Equal(value, response.DeserializeBody<SomeType>());
+        }
+
+        [Fact]
+        public static async Task Error_NoConversion_400WithJson()
+        {
+            var error = new SomeType(123);
+            var result = Result<int, SomeType>.Error(error);
+
+            var httpResult = Results.Extensions.Result(result);
+
+            var response = await httpResult.ToResponse();
+            Assert.Equal(StatusCodes.Status400BadRequest, response.StatusCode);
+            Assert.Equal(error, response.DeserializeBody<SomeType>());
+        }
+
+        [Fact]
+        public static async Task Error_Conversion_UsesConversion()
+        {
+            var error = new SomeType(123);
+            var result = Result<int, SomeType>.Error(error);
+
+            var httpResult = Results.Extensions.Result(result, TypedResults.NotFound);
+
+            var response = await httpResult.ToResponse();
+            Assert.Equal(StatusCodes.Status404NotFound, response.StatusCode);
+            Assert.Equal(error, response.DeserializeBody<SomeType>());
+        }
+    }
+
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicProperties)]
+    private record SomeType(int Value);
+}


### PR DESCRIPTION
This adds extension methods with typed `Microsoft.AspNetCore.Http.Results<TResult1, TResult2>` as return types.

This helps with the generation of OpenAPI documentation and eliminates the need for `[ProducesResponseType]` attributes or calls to the `Produces` extension method with Status codes.